### PR TITLE
FEAT: Add rule: history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +130,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +155,12 @@ dependencies = [
  "redox_users",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "either"
@@ -178,6 +196,21 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "getrandom"
@@ -223,6 +256,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +306,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
+name = "mockall"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "ohcrab"
 version = "0.1.1"
 dependencies = [
@@ -272,6 +356,7 @@ dependencies = [
  "dirs",
  "env_logger",
  "log",
+ "mockall",
  "shellwords",
  "similar",
  "which",
@@ -288,6 +373,36 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "predicates"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -393,6 +508,17 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
@@ -412,6 +538,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
 name = "thiserror"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,7 +560,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,12 +60,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,12 +124,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,13 +186,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-cmp"
-version = "0.9.0"
+name = "fastrand"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
-]
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fragile"
@@ -257,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -307,9 +292,9 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "mockall"
-version = "0.11.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
+checksum = "1a978c8292954bcb9347a4e28772c0a0621166a1598fc1be28ac0076a4bb810e"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -322,29 +307,14 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.11.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
+checksum = "ad2765371d0978ba4ace4ebef047baa62fc068b431e468444b5610dd441c639b"
 dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
-name = "num-traits"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
-dependencies = [
- "autocfg",
+ "syn",
 ]
 
 [[package]]
@@ -359,6 +329,7 @@ dependencies = [
  "mockall",
  "shellwords",
  "similar",
+ "tempfile",
  "which",
 ]
 
@@ -376,16 +347,13 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "predicates"
-version = "2.1.5"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
 dependencies = [
- "difflib",
- "float-cmp",
+ "anstyle",
  "itertools",
- "normalize-line-endings",
  "predicates-core",
- "regex",
 ]
 
 [[package]]
@@ -508,17 +476,6 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
@@ -526,6 +483,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -560,7 +530,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ dirs = "5.0.1"
 lto = true          # Enable link-time optimization
 strip = true        # Strip symbols from binary*
 codegen-units = 1   # Reduce number of codegen units to increase optimizations
+
+[dev-dependencies]
+mockall = "0.11.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,5 @@ strip = true        # Strip symbols from binary*
 codegen-units = 1   # Reduce number of codegen units to increase optimizations
 
 [dev-dependencies]
-mockall = "0.11.4"
+mockall = "0.12.0"
+tempfile = "3.8.1"

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -112,7 +112,10 @@ pub fn shell_command(words_str: &str) -> Command {
 
 #[cfg(test)]
 mod tests {
-    use crate::{cli::command::shell_command, shell::{Bash, Shell}};
+    use crate::{
+        cli::command::shell_command,
+        shell::{Bash, Shell},
+    };
 
     use super::run_command;
 
@@ -128,7 +131,7 @@ mod tests {
     fn test_run_command() {
         let command_vec = vec!["echo".to_owned(), "Hello!".to_owned()];
         let command = command_vec.join(" ").trim().to_owned();
-        let system_shell: Box<dyn Shell> = Box::new(Bash{});
+        let system_shell: Box<dyn Shell> = Box::new(Bash {});
         let crab_command = run_command(command_vec, &system_shell);
         assert_eq!(crab_command.script, command);
         assert_eq!(crab_command.stdout.unwrap(), "Hello!\n");

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -72,7 +72,7 @@ impl CrabCommand {
     }
 }
 
-pub fn run_command(raw_command: Vec<String>, system_shell: Box<dyn Shell>) -> CrabCommand {
+pub fn run_command(raw_command: Vec<String>, system_shell: &Box<dyn Shell>) -> CrabCommand {
     let command = prepare_command(raw_command);
     let mut output = shell_command(&system_shell.get_shell())
         .arg(&command)

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -112,7 +112,7 @@ pub fn shell_command(words_str: &str) -> Command {
 
 #[cfg(test)]
 mod tests {
-    use crate::{cli::command::shell_command, shell::Bash};
+    use crate::{cli::command::shell_command, shell::{Bash, Shell}};
 
     use super::run_command;
 
@@ -128,7 +128,8 @@ mod tests {
     fn test_run_command() {
         let command_vec = vec!["echo".to_owned(), "Hello!".to_owned()];
         let command = command_vec.join(" ").trim().to_owned();
-        let crab_command = run_command(command_vec, Box::new(Bash));
+        let system_shell: Box<dyn Shell> = Box::new(Bash{});
+        let crab_command = run_command(command_vec, &system_shell);
         assert_eq!(crab_command.script, command);
         assert_eq!(crab_command.stdout.unwrap(), "Hello!\n");
         assert_eq!(crab_command.stderr.unwrap(), "");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(unused_mut)]
 #![allow(unused_imports)]
 #![allow(unused_variables)]
+#![allow(clippy::borrowed_box)]
 
 pub mod cli;
 pub mod rules;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(clippy::borrowed_box)]
+#![allow(clippy::type_complexity)]
 
 pub mod cli;
 pub mod rules;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,9 @@ fn main() {
     if let Some(command) = arg_matches.remove_many::<String>("command") {
         let command_vec = command.collect();
         log::debug!("Retrieved command(s): {:?}", command_vec);
-        let mut crab_command = run_command(command_vec, system_shell);
-        let corrected_commands = get_corrected_commands(&mut crab_command);
+        let mut crab_command = run_command(command_vec, &system_shell);
+        log::debug!("Crab command: {:?}", crab_command);
+        let corrected_commands = get_corrected_commands(&mut crab_command, &system_shell);
         log::debug!(
             "Candidate command(s): {:?}",
             corrected_commands

--- a/src/rules/apt_upgrade.rs
+++ b/src/rules/apt_upgrade.rs
@@ -16,7 +16,10 @@ pub fn match_rule(command: &mut CrabCommand, system_shell: Option<&Box<dyn Shell
     match_without_sudo(_match_rule, command)
 }
 
-pub fn get_new_command(command: &CrabCommand, system_shell: Option<&Box<dyn Shell>>) -> Vec<String> {
+pub fn get_new_command(
+    command: &CrabCommand,
+    system_shell: Option<&Box<dyn Shell>>,
+) -> Vec<String> {
     vec!["apt upgrade".to_owned()]
 }
 

--- a/src/rules/apt_upgrade.rs
+++ b/src/rules/apt_upgrade.rs
@@ -16,7 +16,7 @@ pub fn match_rule(command: &mut CrabCommand, system_shell: Option<&Box<dyn Shell
     match_without_sudo(_match_rule, command)
 }
 
-pub fn get_new_command(command: &CrabCommand) -> Vec<String> {
+pub fn get_new_command(command: &CrabCommand, system_shell: Option<&Box<dyn Shell>>) -> Vec<String> {
     vec!["apt upgrade".to_owned()]
 }
 

--- a/src/rules/cargo.rs
+++ b/src/rules/cargo.rs
@@ -1,8 +1,8 @@
-use crate::cli::command::CrabCommand;
+use crate::{cli::command::CrabCommand, shell::Shell};
 
 use super::Rule;
 
-pub fn match_rule(command: &mut CrabCommand) -> bool {
+pub fn match_rule(command: &mut CrabCommand, system_shell: &Box<dyn Shell>) -> bool {
     command.script == "cargo"
 }
 
@@ -24,15 +24,15 @@ pub fn get_rule() -> Rule {
 
 #[cfg(test)]
 mod tests {
-    use crate::{cli::command::CrabCommand, rules::cargo::match_rule};
+    use crate::{cli::command::CrabCommand, rules::cargo::match_rule, shell::Zsh};
 
     #[test]
     fn test_match_rule() {
-        assert!(match_rule(&mut CrabCommand::new(
-            "cargo".to_owned(),
-            Some("multiple\nlines".to_owned()),
-            None
-        )));
+        let system_shell = Box::new(Zsh);
+        assert!(match_rule(
+            &mut CrabCommand::new("cargo".to_owned(), Some("multiple\nlines".to_owned()), None),
+            &system_shell
+        ));
         assert!(!match_rule(&mut CrabCommand::new(
             "acargo".to_owned(),
             Some("multiple\nlines".to_owned()),

--- a/src/rules/cargo.rs
+++ b/src/rules/cargo.rs
@@ -6,7 +6,10 @@ pub fn match_rule(command: &mut CrabCommand, system_shell: Option<&Box<dyn Shell
     command.script == "cargo"
 }
 
-pub fn get_new_command(command: &CrabCommand, system_shell: Option<&Box<dyn Shell>>) -> Vec<String> {
+pub fn get_new_command(
+    command: &CrabCommand,
+    system_shell: Option<&Box<dyn Shell>>,
+) -> Vec<String> {
     vec!["cargo build".to_owned()]
 }
 

--- a/src/rules/cargo.rs
+++ b/src/rules/cargo.rs
@@ -6,7 +6,7 @@ pub fn match_rule(command: &mut CrabCommand, system_shell: Option<&Box<dyn Shell
     command.script == "cargo"
 }
 
-pub fn get_new_command(command: &CrabCommand) -> Vec<String> {
+pub fn get_new_command(command: &CrabCommand, system_shell: Option<&Box<dyn Shell>>) -> Vec<String> {
     vec!["cargo build".to_owned()]
 }
 

--- a/src/rules/history.rs
+++ b/src/rules/history.rs
@@ -1,0 +1,17 @@
+use super::Rule;
+use crate::cli::command::CrabCommand;
+use crate::utils::get_close_matches;
+
+pub fn match_rule(command: &mut CrabCommand) -> bool {
+    command.script == "cargo"
+}
+
+// def match(command):
+//     return len(get_close_matches(command.script,
+//                                  get_valid_history_without_current(command)))
+
+// def get_new_command(command):
+//     return get_closest(command.script,
+//                        get_valid_history_without_current(command))
+
+// priority = 9999

--- a/src/rules/history.rs
+++ b/src/rules/history.rs
@@ -11,10 +11,14 @@ pub fn match_rule(command: &mut CrabCommand, system_shell: Option<&Box<dyn Shell
             .map(|s| s.as_str())
             .collect::<Vec<&str>>()
             .as_slice(),
-    ).is_empty()
+    )
+    .is_empty()
 }
 
-pub fn get_new_command(command: &CrabCommand, system_shell: Option<&Box<dyn Shell>>) -> Vec<String> {
+pub fn get_new_command(
+    command: &CrabCommand,
+    system_shell: Option<&Box<dyn Shell>>,
+) -> Vec<String> {
     get_close_matches(
         &command.script,
         get_valid_history_without_current(command, system_shell.unwrap())
@@ -22,7 +26,10 @@ pub fn get_new_command(command: &CrabCommand, system_shell: Option<&Box<dyn Shel
             .map(|s| s.as_str())
             .collect::<Vec<&str>>()
             .as_slice(),
-    ).iter().map(|&s| s.to_string()).collect()
+    )
+    .iter()
+    .map(|&s| s.to_string())
+    .collect()
 }
 
 pub fn get_rule() -> Rule {

--- a/src/rules/history.rs
+++ b/src/rules/history.rs
@@ -4,22 +4,20 @@ use crate::shell::Shell;
 use crate::utils::{get_close_matches, get_valid_history_without_current};
 
 pub fn match_rule(command: &mut CrabCommand, system_shell: Option<&Box<dyn Shell>>) -> bool {
-    get_close_matches(
+    !get_close_matches(
         &command.script,
-        get_valid_history_without_current(&command, system_shell.unwrap())
+        get_valid_history_without_current(command, system_shell.unwrap())
             .iter()
             .map(|s| s.as_str())
             .collect::<Vec<&str>>()
             .as_slice(),
-    )
-    .len()
-        > 0
+    ).is_empty()
 }
 
 pub fn get_new_command(command: &CrabCommand, system_shell: Option<&Box<dyn Shell>>) -> Vec<String> {
     get_close_matches(
         &command.script,
-        get_valid_history_without_current(&command, system_shell.unwrap())
+        get_valid_history_without_current(command, system_shell.unwrap())
             .iter()
             .map(|s| s.as_str())
             .collect::<Vec<&str>>()

--- a/src/rules/history.rs
+++ b/src/rules/history.rs
@@ -1,9 +1,30 @@
 use super::Rule;
 use crate::cli::command::CrabCommand;
-use crate::utils::get_close_matches;
+use crate::shell::Shell;
+use crate::utils::{get_close_matches, get_valid_history_without_current};
 
 pub fn match_rule(command: &mut CrabCommand, system_shell: Option<&Box<dyn Shell>>) -> bool {
-    command.script == "cargo"
+    get_close_matches(
+        &command.script,
+        get_valid_history_without_current(&command, system_shell.unwrap())
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<&str>>()
+            .as_slice(),
+    )
+    .len()
+        > 0
+}
+
+pub fn get_new_command(command: &CrabCommand, system_shell: Option<&Box<dyn Shell>>) -> Vec<String> {
+    get_close_matches(
+        &command.script,
+        get_valid_history_without_current(&command, system_shell.unwrap())
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<&str>>()
+            .as_slice(),
+    ).iter().map(|&s| s.to_string()).collect()
 }
 
 pub fn get_rule() -> Rule {
@@ -17,13 +38,5 @@ pub fn get_rule() -> Rule {
         None,
     )
 }
-
-// def match(command):
-//     return len(get_close_matches(command.script,
-//                                  get_valid_history_without_current(command)))
-
-// def get_new_command(command):
-//     return get_closest(command.script,
-//                        get_valid_history_without_current(command))
 
 // priority = 9999

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -12,8 +12,8 @@ use crate::{
 mod apt_get;
 mod apt_upgrade;
 mod cargo;
-mod no_command;
 mod history;
+mod no_command;
 
 pub struct Rule {
     name: String,
@@ -64,9 +64,16 @@ impl Rule {
         false
     }
 
-    fn get_corrected_commands(&self, command: &CrabCommand, system_shell: &Box<dyn Shell>) -> Vec<CorrectedCommand> {
+    fn get_corrected_commands(
+        &self,
+        command: &CrabCommand,
+        system_shell: &Box<dyn Shell>,
+    ) -> Vec<CorrectedCommand> {
         let mut new_commands: Vec<CorrectedCommand> = vec![];
-        for (n, new_command) in (self.get_new_command)(command, Some(system_shell)).iter().enumerate() {
+        for (n, new_command) in (self.get_new_command)(command, Some(system_shell))
+            .iter()
+            .enumerate()
+        {
             new_commands.push(CorrectedCommand::new(
                 new_command.to_owned(),
                 self.side_effect,
@@ -132,6 +139,6 @@ pub fn get_rules() -> Vec<Rule> {
         cargo::get_rule(),
         no_command::get_rule(),
         apt_upgrade::get_rule(),
-        history::get_rule()
+        history::get_rule(),
     ]
 }

--- a/src/rules/no_command.rs
+++ b/src/rules/no_command.rs
@@ -1,6 +1,7 @@
 use crate::{
     cli::command::CrabCommand,
-    utils::{get_all_executable, get_close_matches}, shell::Shell,
+    shell::Shell,
+    utils::{get_all_executable, get_close_matches},
 };
 use similar::DiffableStr;
 use which::which;
@@ -25,7 +26,7 @@ pub fn match_rule(command: &mut CrabCommand, system_shell: Option<&Box<dyn Shell
         .is_empty()
 }
 
-pub fn get_new_command(command: &CrabCommand) -> Vec<String> {
+pub fn get_new_command(command: &CrabCommand, system_shell: Option<&Box<dyn Shell>>) -> Vec<String> {
     let old_command = &command.script_parts[0];
     let old_parameters = {
         if command.script_parts.len() > 1 {

--- a/src/rules/no_command.rs
+++ b/src/rules/no_command.rs
@@ -26,7 +26,10 @@ pub fn match_rule(command: &mut CrabCommand, system_shell: Option<&Box<dyn Shell
         .is_empty()
 }
 
-pub fn get_new_command(command: &CrabCommand, system_shell: Option<&Box<dyn Shell>>) -> Vec<String> {
+pub fn get_new_command(
+    command: &CrabCommand,
+    system_shell: Option<&Box<dyn Shell>>,
+) -> Vec<String> {
     let old_command = &command.script_parts[0];
     let old_parameters = {
         if command.script_parts.len() > 1 {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -141,8 +141,8 @@ impl Shell for Zsh {
     }
 
     fn script_from_history(&self, command_script: &str) -> String {
-        if command_script.contains(";") {
-            command_script.splitn(2, ";").nth(1).unwrap().to_owned()
+        if command_script.contains(';') {
+            command_script.split_once(';').unwrap().1.to_owned()
         } else {
             "".to_owned()
         }
@@ -222,7 +222,7 @@ mod test_zsh {
 
         let system_shell = Zsh {};
         assert_eq!(
-            system_shell.get_history(Some(&path)),
+            system_shell.get_history(Some(path)),
             vec!["ls -lah", "cd /tmp", "nvim"]
         );
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,8 @@ use similar::get_close_matches as difflib_get_close_matches;
 use std::env;
 use std::path::Path;
 
+use crate::cli::command::CrabCommand;
+
 /// Gets a list of close matches for a word from a list of possibilities.
 ///
 /// # Arguments
@@ -60,3 +62,25 @@ pub fn get_all_executable() -> Vec<String> {
     // TODO: Add shell aliases
     bins
 }
+
+pub fn get_valid_history_without_current(command: &CrabCommand) {}
+// def get_valid_history_without_current(command):
+//     def _not_corrected(history, tf_alias):
+//         """Returns all lines from history except that comes before `fuck`."""
+//         previous = None
+//         for line in history:
+//             if previous is not None and line != tf_alias:
+//                 yield previous
+//             previous = line
+//         if history:
+//             yield history[-1]
+
+//     from thefuck.shells import shell
+//     history = shell.get_history()
+//     tf_alias = get_alias()
+//     executables = set(get_all_executables())\
+//         .union(shell.get_builtin_commands())
+
+//     return [line for line in _not_corrected(history, tf_alias)
+//             if not line.startswith(tf_alias) and not line == command.script
+//             and line.split(' ')[0] in executables]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -97,7 +97,7 @@ fn not_corrected(history: &Vec<String>, oc_alias: &String) -> Vec<String> {
 
 /// Returns a vector of valid history commands excluding the current command.
 ///
-/// The method compares the command with executables and shell builtins and 
+/// The method compares the command with executables and shell builtins and
 /// ignores commands performed just after the alias is called ("crab").
 ///
 /// # Arguments
@@ -156,21 +156,20 @@ mod tests {
 
     #[test]
     fn test_get_valid_history_without_current() {
-        let command = CrabCommand::new("ls -l".to_owned(), Some("multiple\nlines".to_owned()), None);
+        let command =
+            CrabCommand::new("ls -l".to_owned(), Some("multiple\nlines".to_owned()), None);
         // let mock_shell: Box<dyn Shell> = Box::new(MockShell {});
         let mut mock_shell = MockMyShell::new();
         mock_shell
             .expect_get_builtin_commands()
             .returning(|| vec!["command1".to_string(), "command2".to_string()]);
-        mock_shell
-            .expect_get_history()
-            .returning(|_| {
-                vec![
-                    "ls -l".to_string(),
-                    "command1".to_string(),
-                    "cmp a.txt b.txt".to_string(),
-                ]
-            });
+        mock_shell.expect_get_history().returning(|_| {
+            vec![
+                "ls -l".to_string(),
+                "command1".to_string(),
+                "cmp a.txt b.txt".to_string(),
+            ]
+        });
         let system_shell: Box<dyn Shell> = Box::new(mock_shell);
 
         assert_eq!(
@@ -182,15 +181,13 @@ mod tests {
         mock_shell
             .expect_get_builtin_commands()
             .returning(|| vec!["command1".to_string(), "command2".to_string()]);
-        mock_shell
-            .expect_get_history()
-            .returning(|_| {
-                vec![
-                    "ls -l".to_string(),
-                    "cmp a.txt b.txt".to_string(),
-                    get_alias()
-                ]
-            });
+        mock_shell.expect_get_history().returning(|_| {
+            vec![
+                "ls -l".to_string(),
+                "cmp a.txt b.txt".to_string(),
+                get_alias(),
+            ]
+        });
         let system_shell: Box<dyn Shell> = Box::new(mock_shell);
         // Skip "cmp a.txt b.txt" because it comes before "crab" (alias)
         assert_eq!(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -111,25 +111,6 @@ pub fn get_valid_history_without_current(
     valid_history
 }
 
-// def get_valid_history_without_current(command):
-//     def _not_corrected(history, tf_alias):
-//         """Returns all lines from history except that comes before `fuck`."""
-//         previous = None
-//         for line in history:
-//             if previous is not None and line != tf_alias:
-//                 yield previous
-//             previous = line
-//         if history:
-//             yield history[-1]
-//     from thefuck.shells import shell
-//     history = shell.get_history()
-//     tf_alias = get_alias()
-//     executables = set(get_all_executables())\
-//         .union(shell.get_builtin_commands())
-//     return [line for line in _not_corrected(history, tf_alias)
-//             if not line.startswith(tf_alias) and not line == command.script
-//             and line.split(' ')[0] in executables]
-
 #[cfg(test)]
 mod tests {
     use mockall::{mock, predicate};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -66,6 +66,16 @@ pub fn get_all_executable() -> Vec<String> {
     bins
 }
 
+/// Filters out history entries occurring immediately after the alias ("crab").
+///
+/// # Arguments
+///
+/// * `history` - A reference to a vector of strings representing the history.
+/// * `oc_alias` - A reference to a string representing the alias to be filtered out.
+///
+/// # Returns
+///
+/// * Vector of strings where entries immediately after the alias have been filtered out.
 fn not_corrected(history: &Vec<String>, oc_alias: &String) -> Vec<String> {
     let mut previous: Option<&str> = None;
     let mut result = Vec::new();
@@ -85,6 +95,19 @@ fn not_corrected(history: &Vec<String>, oc_alias: &String) -> Vec<String> {
     result
 }
 
+/// Returns a vector of valid history commands excluding the current command.
+///
+/// The method compares the command with executables and shell builtins and 
+/// ignores commands performed just after the alias is called ("crab").
+///
+/// # Arguments
+///
+/// * `command` - A reference to the current CrabCommand.
+/// * `system_shell` - A reference to the system shell.
+///
+/// # Returns
+///
+/// * A vector of valid history commands as strings.
 pub fn get_valid_history_without_current(
     command: &CrabCommand,
     system_shell: &Box<dyn Shell>,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -93,11 +93,12 @@ pub fn get_valid_history_without_current(
     let mut corrected: Vec<String> = Vec::new();
     let mut valid_history: Vec<String> = Vec::new();
 
-    let mut executables = system_shell.get_history();
+    let history = system_shell.get_history(None);
+    let mut executables = history.clone();
     executables.extend(system_shell.get_builtin_commands());
     let executables: HashSet<_> = executables.into_iter().collect();
 
-    for line in not_corrected(&system_shell.get_history(), &get_alias()) {
+    for line in not_corrected(&history, &get_alias()) {
         let first_word = line.split_whitespace().next().unwrap_or(line.as_str());
         if !line.starts_with(&get_alias())
             & (line != command.script)
@@ -120,14 +121,29 @@ pub fn get_valid_history_without_current(
 //             previous = line
 //         if history:
 //             yield history[-1]
-
 //     from thefuck.shells import shell
 //     history = shell.get_history()
 //     tf_alias = get_alias()
 //     executables = set(get_all_executables())\
 //         .union(shell.get_builtin_commands())
-
 //     return [line for line in _not_corrected(history, tf_alias)
 //             if not line.startswith(tf_alias) and not line == command.script
 //             and line.split(' ')[0] in executables]
-//
+
+#[cfg(test)]
+mod tests {
+    use mockall::{automock,predicate::*};
+
+    #[automock]
+    trait MockShell {
+        fn get_history<'a>(&self, file_path: Option<&'a str>) -> Vec<String>;
+        fn get_builtin_commands(&self) -> Vec<String>;
+    }
+
+    fn test_get_valid_history_without_current() {
+        let mut mock = MockMyTrait::new();
+        mock.expect_get_history()
+
+        
+    }
+}


### PR DESCRIPTION
The history rule compare the command against the shell history (+ executables and shell builtins) to see if there are fuzzy matches that are returned as candidates.