### PR TITLE
Feat: Add rule: cd - cs

### DIFF
--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -56,13 +56,13 @@ impl fmt::Display for CrabCommand {
 
 impl CrabCommand {
     pub fn new(script: String, stdout: Option<String>, stderr: Option<String>) -> Self {
-        let split_command = CrabCommand::split_command(&script);
+        let split_parts = CrabCommand::split_command(&script);
 
         CrabCommand {
             script,
             stdout,
             stderr,
-            script_parts: split_command,
+            script_parts: split_parts,
         }
     }
 

--- a/src/rules/cd_cs.rs
+++ b/src/rules/cd_cs.rs
@@ -1,0 +1,71 @@
+use crate::{cli::command::CrabCommand, shell::Shell};
+
+use super::{match_without_sudo, Rule};
+
+pub fn match_rule(command: &mut CrabCommand, system_shell: Option<&dyn Shell>) -> bool {
+    command.script_parts[0] == "cs"
+}
+
+pub fn get_new_command(command: &CrabCommand, system_shell: Option<&dyn Shell>) -> Vec<String> {
+    vec!["cd".to_owned() + &command.script[2..]]
+}
+
+/// Redirects cs to cd when there is a typo
+/// Due to the proximity of the keys - d and s - this seems like a common typo
+///
+/// $ cs /etc/
+/// cs: command not found
+/// $ crab
+/// cd /etc/ [enter/↑/↓/ctrl+c]
+pub fn get_rule() -> Rule {
+    Rule::new(
+        "cd_cs".to_owned(),
+        None,
+        None,
+        None,
+        match_rule,
+        get_new_command,
+        None,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get_new_command, match_rule};
+    use crate::cli::command::CrabCommand;
+
+    #[test]
+    fn test_match_rule() {
+        assert!(match_rule(
+            &mut CrabCommand::new(
+                "cs".to_owned(),
+                Some("cs: command not found".to_owned()),
+                None
+            ),
+            None
+        ));
+        assert!(match_rule(
+            &mut CrabCommand::new(
+                "cs /etc/".to_owned(),
+                Some("cs: command not found".to_owned()),
+                None
+            ),
+            None
+        ));
+    }
+
+    #[test]
+    fn test_get_new_command() {
+        assert_eq!(
+            get_new_command(
+                &mut CrabCommand::new(
+                    "cs /etc/".to_owned(),
+                    Some("cs: command not found".to_owned()),
+                    None
+                ),
+                None
+            ),
+            vec!["cd /etc/"]
+        )
+    }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 mod apt_get;
 mod apt_upgrade;
 mod cargo;
+mod cd_cs;
 mod history;
 mod no_command;
 mod tmux;
@@ -139,6 +140,7 @@ pub fn get_rules() -> Vec<Rule> {
     vec![
         apt_upgrade::get_rule(),
         cargo::get_rule(),
+        cd_cs::get_rule(),
         history::get_rule(),
         no_command::get_rule(),
         tmux::get_rule(),


### PR DESCRIPTION
Rule that replace cs by cd given that "s" and "d" are very close in the keyboard.