### PR TITLE
BUG: Fix git support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,7 +453,7 @@ dependencies = [
  "mockall",
  "regex",
  "rstest",
- "shellwords",
+ "shlex",
  "tempfile",
  "which",
 ]
@@ -640,14 +640,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
-name = "shellwords"
-version = "1.1.0"
+name = "shlex"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e515aa4699a88148ed5ef96413ceef0048ce95b43fbc955a33bde0a70fcae6"
-dependencies = [
- "lazy_static",
- "regex",
-]
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.70.0"
 
 [dependencies]
 clap = { version = "4.4.7", features = ["cargo", "env"] }
-shellwords = "1.1.0"
+shlex = "1.3.0"
 which = "4.4.0"
 fuzzt = "0.1.0"
 console = "0.15.7"

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2015-2022 Vladimir Iakovlev
 Copyright (c) 2023 Luiz Otavio Vilas Boas Oliveira
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -74,8 +74,8 @@ impl CrabCommand {
     ) -> CrabCommand {
         CrabCommand::new(
             script.unwrap_or(self.script.to_owned()),
-            stdout.map_or(self.stdout.to_owned(), |s| Some(s)),
-            stderr.map_or(self.stderr.to_owned(), |s| Some(s)),
+            stdout.map_or(self.stdout.to_owned(), Some),
+            stderr.map_or(self.stderr.to_owned(), Some),
         )
     }
 

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -1,4 +1,4 @@
-use shellwords;
+use shlex::split;
 use std::process::{Command, Stdio};
 use std::{fmt, str};
 
@@ -66,9 +66,22 @@ impl CrabCommand {
         }
     }
 
+    pub fn update(
+        &self,
+        script: Option<String>,
+        stdout: Option<String>,
+        stderr: Option<String>,
+    ) -> CrabCommand {
+        CrabCommand::new(
+            script.unwrap_or(self.script.to_owned()),
+            stdout.map_or(self.stdout.to_owned(), |s| Some(s)),
+            stderr.map_or(self.stderr.to_owned(), |s| Some(s)),
+        )
+    }
+
     fn split_command(command: &str) -> Vec<String> {
         // Split the command using shell-like syntax.
-        shellwords::split(command).expect("")
+        split(command).expect("")
     }
 }
 
@@ -96,7 +109,7 @@ fn prepare_command(raw_command: Vec<String>) -> String {
 }
 
 pub fn shell_command(words_str: &str) -> Command {
-    let mut words_vec = shellwords::split(words_str).expect("empty shell command");
+    let mut words_vec = split(words_str).expect("empty shell command");
     let mut words = words_vec.iter_mut();
     let first_cmd = words.next().expect("absent shell binary");
     let dash_c = if words_str.contains("cmd.exe") {

--- a/src/rules/utils/git.rs
+++ b/src/rules/utils/git.rs
@@ -1,5 +1,7 @@
 use crate::{cli::command::CrabCommand, shell::Shell};
 use regex::Regex;
+use shlex::split as shlex_split;
+use shlex::Quoter;
 use std::path::Path;
 
 /// Checks if a given command is an application.
@@ -91,33 +93,114 @@ where
     if !is_app(command, vec!["git", "hub"], None) {
         return Vec::<String>::new();
     }
+    let mut new_command = command;
 
     // perform git aliases expansion
-    if let Some(stdout) = &command.stdout {
+    if let Some(stdout) = &new_command.stdout {
         if stdout.contains("trace: alias expansion:") {
             let re = Regex::new(r"trace: alias expansion: ([^ ]*) => ([^\n]*)").unwrap();
             if let Some(search) = re.captures(stdout) {
+                let shlex_quoter = Quoter::new();
                 let alias = search.get(1).map_or("", |m| m.as_str());
 
                 // by default git quotes everything, for example:
                 //     'commit' '--amend'
                 // which is surprising and does not allow to easily test for
                 // eg. 'git commit'
-                let expansion = search
-                    .get(2)
-                    .map_or("", |m| m.as_str())
-                    .split_whitespace()
-                    .map(|part| format!("\"{}\"", part)) // shell.quote(part)
+                let expansion = search.get(2).map_or("", |m| m.as_str());
+                let expansion = shlex_split(expansion)
+                    .unwrap()
+                    .iter()
+                    .map(|s| shlex_quoter.quote(s).unwrap())
                     .collect::<Vec<_>>()
                     .join(" ");
-                let new_script = command
-                    .script
-                    .replace(&format!(r"\b{}\b", alias), &expansion);
 
-                command.script = new_script;
+                let re = Regex::new(&format!(r"\b{}\b", alias)).unwrap();
+                let new_script = re.replace(&new_command.script, &expansion);
+
+                *new_command = new_command.update(Some(new_script.to_string()), None, None);
             }
         }
     }
 
-    func(command, system_shell)
+    func(new_command, system_shell)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get_command_with_git_support, is_app, match_rule_with_git_support};
+    use crate::cli::command::CrabCommand;
+    use crate::shell::{Bash, Shell};
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("/usr/bin/git diff", vec!["git", "hub"], None, true)]
+    #[case("/bin/hdfs dfs -rm foo", vec!["hdfs"], None, true)]
+    #[case("git diff", vec!["git", "hub"], None, true)]
+    #[case("hub diff", vec!["git", "hub"], None, true)]
+    #[case("hg diff", vec!["git", "hub"], None, false)]
+    #[case("/path/to/app run", vec!["app"], Some(1), true)]
+    #[case("/path/to/app run", vec!["app"], Some(0), true)]
+    #[case("/path/to/app", vec!["app"], None, true)]
+    #[case("/path/to/app", vec!["app"], Some(0), true)]
+    #[case("/path/to/app", vec!["app"], Some(1), false)]
+    fn test_is_app(
+        #[case] script: &str,
+        #[case] app_names: Vec<&str>,
+        #[case] at_least: Option<usize>,
+        #[case] is_app_bool: bool,
+    ) {
+        let mut command = CrabCommand::new(script.to_owned(), None, None);
+        assert_eq!(is_app(&command, app_names, at_least), is_app_bool);
+    }
+
+    #[rstest]
+    #[case("git co", "git checkout", vec!["19:22:36.299340 git.c:282   trace: alias expansion: co => 'checkout'"])]
+    #[case("git com file", "git commit --verbose file", vec!["19:23:25.470911 git.c:282   trace: alias expansion: com => 'commit' '--verbose'"])]
+    #[case("git com -m \"Initial commit\"", "git commit -m \"Initial commit\"", vec!["19:22:36.299340 git.c:282   trace: alias expansion: com => \"commit\""])]
+    #[case("git br -d some_branch", "git branch -d some_branch", vec!["19:22:36.299340 git.c:282   trace: alias expansion: br => 'branch'"])]
+    fn test_match_rule_with_git_support(
+        #[case] script: &str,
+        #[case] output: &str,
+        #[case] expected: Vec<&str>,
+    ) {
+        let mut command = CrabCommand::new(script.to_owned(), Some(output.to_owned()), None);
+        let func = |command: &CrabCommand| true;
+        assert_eq!(match_rule_with_git_support(func, &mut command), true);
+    }
+
+    #[rstest]
+    #[case(
+        "git co",
+        "19:22:36.299340 git.c:282   trace: alias expansion: co => 'checkout'",
+        "git checkout"
+    )]
+    #[case(
+        "git com file",
+        "19:23:25.470911 git.c:282   trace: alias expansion: com => 'commit' '--verbose'",
+        "git commit --verbose file"
+    )]
+    #[case(
+        "git com -m \"Initial commit\"",
+        "19:22:36.299340 git.c:282   trace: alias expansion: com => \"commit\"",
+        "git commit -m \"Initial commit\""
+    )]
+    #[case(
+        "git br -d some_branch",
+        "19:22:36.299340 git.c:282   trace: alias expansion: br => 'branch'",
+        "git branch -d some_branch"
+    )]
+    fn test_get_command_with_git_support(
+        #[case] script: &str,
+        #[case] output: &str,
+        #[case] expected: &str,
+    ) {
+        let mut command = CrabCommand::new(script.to_owned(), Some(output.to_owned()), None);
+        let func =
+            |command: &CrabCommand, shell: Option<&dyn Shell>| vec![command.script.to_owned()];
+        assert_eq!(
+            get_command_with_git_support(func, &mut command, None),
+            vec![expected]
+        );
+    }
 }


### PR DESCRIPTION
There were issues with the `get_command_with_git_support` and `match_rule_with_git_support`, resulting in malfunctioning of the rules using these methods (similar to the decorator `git_support` from `thefuck`).