### PR TITLE
ENH: Reduce dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,19 +169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "env_logger"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,34 +309,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
-
-[[package]]
 name = "home"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -401,12 +365,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
-name = "log"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
-
-[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,10 +404,8 @@ dependencies = [
  "clap",
  "console",
  "dirs",
- "env_logger",
  "fuzzt",
  "is_executable",
- "log",
  "mockall",
  "regex",
  "rstest",
@@ -685,15 +641,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,15 +717,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,6 @@ shlex = "1.3.0"
 which = "4.4.0"
 fuzzt = { version = "0.3.1", default-features = false }
 console = "0.15.7"
-log = "0.4.20"
-env_logger = "0.10.0"
 dirs = "5.0.1"
 regex = "1.10.2"
 is_executable = "1.0.1"

--- a/src/rules/cd_correction.rs
+++ b/src/rules/cd_correction.rs
@@ -110,6 +110,6 @@ mod tests {
     #[case("", "", false)]
     fn test_match(#[case] command: &str, #[case] stderr: &str, #[case] is_match: bool) {
         let mut command = CrabCommand::new(command.to_owned(), None, Some(stderr.to_owned()));
-        assert_eq!(auxiliary_match_rule(&mut command), is_match);
+        assert_eq!(auxiliary_match_rule(&command), is_match);
     }
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -225,7 +225,3 @@ pub fn organize_commands(mut corrected_commands: Vec<CorrectedCommand>) -> Vec<C
     corrected_commands.dedup_by(|a, b| a.script.eq(&b.script));
     corrected_commands
 }
-
-pub fn selected_command(corrected_commands: &[CorrectedCommand]) -> Option<&CorrectedCommand> {
-    interactive_menu(corrected_commands)
-}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,10 +1,7 @@
 use crate::shell::Shell;
 use core::fmt;
 
-use crate::{
-    cli::{command::CorrectedCommand, command::CrabCommand},
-    ui::interactive_menu,
-};
+use crate::cli::{command::CorrectedCommand, command::CrabCommand};
 
 mod ag_literal;
 mod apt_get;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,7 +9,7 @@ use crate::shell::Shell;
 
 use regex::Regex;
 
-/// This function prints a message to the console when the program is 
+/// This function prints a message to the console when the program is
 /// compiled in debug mode and does nothing in release mode.
 ///
 /// # Arguments

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,6 +9,28 @@ use crate::shell::Shell;
 
 use regex::Regex;
 
+/// This function prints a message to the console when the program is 
+/// compiled in debug mode and does nothing in release mode.
+///
+/// # Arguments
+///
+/// * `message` - A string slice that holds the message to be logged.
+///
+/// # Examples
+///
+/// ```
+/// debug_log("This is a debug log message.");
+/// ```
+#[cfg(debug_assertions)]
+pub fn debug_log(message: &str) {
+    println!("{}", message);
+}
+
+#[cfg(not(debug_assertions))]
+pub fn debug_log(_: &str) {
+    // This function does nothing when not in debug mode.
+}
+
 /// Replaces an argument in a script.
 ///
 /// This function takes a script and two strings `from_` and `to`. It replaces the last occurrence of `from_` in the script with `to`.


### PR DESCRIPTION
Remove log and env_logger from the list of dependencies, to reduce the size of the binary and speedup compilation.